### PR TITLE
Fix parser on OSX

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,13 +34,19 @@ module.exports.parse = function( output ){
         if( index == 0 ){
             var fields = line.split( /\s+/ );
             // 保存各字段的开始和结束位置
+            var fieldIndex = 0;
             fields.forEach(function( field ){
 
                 if( field ){
                     var info = titleInfo[ field ] = {};
                     // 记录字段值的开始和结束
-                    info.titleBegin = line.indexOf( field );
+                    if ( fieldIndex == 0 ){
+                        info.titleBegin = 0;
+                    }else{
+                        info.titleBegin = line.indexOf( field );
+                    }
                     info.titleEnd = info.titleBegin + field.length - 1;
+                    fieldIndex++;
                 }
             });
         }


### PR DESCRIPTION
There seemed to be a problem with `ps-node` due to the `PID` not being returned.

This is because, on OSX, the table looks like this:

```
  PID TTY           TIME CMD
 4773 ttys000    0:00.30 -/bin/zsh
13225 ttys001    0:00.16 -/bin/zsh
13435 ttys002    0:00.11 -/bin/zsh
```

Notice that the `PID` starts with two spaces, but `titleBegin` was being set to `2` instead of `0`. 

The fix may be naive but it seems to work on OSX. Hopefully this doesn't break it on other OS. 
